### PR TITLE
Use separate trusted IP lists for ssh and VPN

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ has been applied
 | provisionopenvpn_policy_name | The name to assign the IAM policy that allows provisioning of OpenVPN in the Shared Services account. | `string` | `ProvisionOpenVPN` | no |
 | public_zone_name | The name of the public Route53 zone where public DNS records should be created (e.g. "cyber.dhs.gov."). | `string` | `cyber.dhs.gov.` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
-| trusted_cidr_blocks | A list of the CIDR blocks outside the VPC that are allowed to access the IPA servers (e.g. ["10.10.0.0/16", "10.11.0.0/16"]). | `list(string)` | `[]` | no |
+| trusted_cidr_blocks_ssh | A list of the CIDR blocks that are allowed to access the ssh port on the VPN servers (e.g. ["10.10.0.0/16", "10.11.0.0/16"]). | `list(string)` | `[]` | no |
+| trusted_cidr_blocks_vpn | A list of the CIDR blocks that are allowed to access the VPN port on the VPN servers (e.g. ["10.10.0.0/16", "10.11.0.0/16"]). | `list(string)` | `[]` | no |
 
 ## Outputs ##
 

--- a/openvpn.tf
+++ b/openvpn.tf
@@ -27,7 +27,7 @@ locals {
 }
 
 module "openvpn" {
-  source = "github.com/cisagov/openvpn-server-tf-module"
+  source = "github.com/cisagov/openvpn-server-tf-module?ref=improvement%2Fseparate-trusted-ip-lists-for-ssh-and-vpn"
 
   providers = {
     aws                = aws
@@ -58,7 +58,8 @@ module "openvpn" {
   ssm_read_role_accounts_allowed = [
     data.aws_caller_identity.default.account_id
   ]
-  subnet_id           = data.terraform_remote_state.networking.outputs.public_subnets[local.openvpn_subnet_cidr].id
-  tags                = var.tags
-  trusted_cidr_blocks = var.trusted_cidr_blocks
+  subnet_id               = data.terraform_remote_state.networking.outputs.public_subnets[local.openvpn_subnet_cidr].id
+  tags                    = var.tags
+  trusted_cidr_blocks_ssh = var.trusted_cidr_blocks_ssh
+  trusted_cidr_blocks_vpn = var.trusted_cidr_blocks_vpn
 }

--- a/openvpn.tf
+++ b/openvpn.tf
@@ -27,7 +27,7 @@ locals {
 }
 
 module "openvpn" {
-  source = "github.com/cisagov/openvpn-server-tf-module?ref=improvement%2Fseparate-trusted-ip-lists-for-ssh-and-vpn"
+  source = "github.com/cisagov/openvpn-server-tf-module"
 
   providers = {
     aws                = aws

--- a/variables.tf
+++ b/variables.tf
@@ -82,8 +82,14 @@ variable "tags" {
   default     = {}
 }
 
-variable "trusted_cidr_blocks" {
+variable "trusted_cidr_blocks_ssh" {
   type        = list(string)
-  description = "A list of the CIDR blocks outside the VPC that are allowed to access the IPA servers (e.g. [\"10.10.0.0/16\", \"10.11.0.0/16\"])."
+  description = "A list of the CIDR blocks that are allowed to access the ssh port on the VPN servers (e.g. [\"10.10.0.0/16\", \"10.11.0.0/16\"])."
+  default     = []
+}
+
+variable "trusted_cidr_blocks_vpn" {
+  type        = list(string)
+  description = "A list of the CIDR blocks that are allowed to access the VPN port on the VPN servers (e.g. [\"10.10.0.0/16\", \"10.11.0.0/16\"])."
   default     = []
 }


### PR DESCRIPTION
## 🗣 Description

In this PR we change the code to use separate trusted IP lists for ssh and VPN.  See also cisagov/openvpn-server-tf-module#14.

## 💭 Motivation and Context

We need VPN to be accessible from any IP (since we have folks on travel) but we want to keep ssh restricted.

## 🧪 Testing

All pre-commit tests pass.  This code has already been deployed to production and works great by all accounts.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
