### PR TITLE
Do not hardcode workspace name in remote state configurations

### DIFF
--- a/remote_states.tf
+++ b/remote_states.tf
@@ -16,7 +16,7 @@ data "terraform_remote_state" "networking" {
     key            = "cool-sharedservices-networking/terraform.tfstate"
   }
 
-  workspace = "production"
+  workspace = terraform.workspace
 }
 
 data "terraform_remote_state" "freeipa" {
@@ -31,5 +31,5 @@ data "terraform_remote_state" "freeipa" {
     key            = "cool-sharedservices-freeipa/terraform.tfstate"
   }
 
-  workspace = "production"
+  workspace = terraform.workspace
 }


### PR DESCRIPTION
## 🗣 Description

The workspace name in remote state configurations was previously hardcoded to "production".  This PR changes the code to instead use `terraform.workspace`, so that the workspace name changes as we switch between the production and staging environments.

I also went ahead and took the opportunity to pull in the latest from the upstream [cisagov/skeleton-tf-module](https://github.com/cisagov/skeleton-tf-module) skeleton.

## 💭 Motivation and Context

We need to be able to switch as seamlessly as possible between the production and staging environments.  The more manual foo that is required the more likely that we make a mistake and damage production.

## 🧪 Testing

These changes were successfully deployed to staging.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
