### PR TITLE
Dynamically determine the correct Images account to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ has been applied
 | provisionaccount_role_name | The name of the IAM role that allows sufficient permissions to provision all AWS resources in the Shared Services account. | `string` | `ProvisionAccount` | no |
 | provisionopenvpn_policy_description | The description to associate with the IAM policy that allows provisioning of OpenVPN in the Shared Services account. | `string` | `Allows provisioning of OpenVPN in the Shared Services account.` | no |
 | provisionopenvpn_policy_name | The name to assign the IAM policy that allows provisioning of OpenVPN in the Shared Services account. | `string` | `ProvisionOpenVPN` | no |
-| public_zone_name | The name of the public Route53 zone where public DNS records should be created (e.g. "cyber.dhs.gov."). | `string` | `cyber.dhs.gov.` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
 | trusted_cidr_blocks_ssh | A list of the CIDR blocks that are allowed to access the ssh port on the VPN servers (e.g. ["10.10.0.0/16", "10.11.0.0/16"]). | `list(string)` | `[]` | no |
 | trusted_cidr_blocks_vpn | A list of the CIDR blocks that are allowed to access the VPN port on the VPN servers (e.g. ["10.10.0.0/16", "10.11.0.0/16"]). | `list(string)` | `[]` | no |

--- a/caller_identity.tf
+++ b/caller_identity.tf
@@ -1,0 +1,6 @@
+# ------------------------------------------------------------------------------
+# We can get the account ID of the Shared Services account from the
+# provider's caller identity.
+# ------------------------------------------------------------------------------
+data "aws_caller_identity" "sharedservices" {
+}

--- a/openvpn.tf
+++ b/openvpn.tf
@@ -62,13 +62,13 @@ module "openvpn" {
   client_dns_search_domain = var.client_dns_search_domain
   client_dns_server        = var.client_dns_server
   client_network           = var.client_network
-  domain                   = var.public_zone_name
   freeipa_admin_pw         = var.freeipa_admin_pw
   freeipa_realm            = upper(var.cool_domain)
   hostname                 = "vpn.${var.cool_domain}"
   private_networks         = var.private_networks
   private_reverse_zone_id  = data.terraform_remote_state.networking.outputs.public_subnet_private_reverse_zones[local.openvpn_subnet_cidr].id
   private_zone_id          = data.terraform_remote_state.networking.outputs.private_zone.id
+  public_zone_id           = data.terraform_remote_state.public_dns.outputs.cyber_dhs_gov_zone.id
   security_groups = [
     data.terraform_remote_state.freeipa.outputs.client_security_group.id
   ]

--- a/openvpn.tf
+++ b/openvpn.tf
@@ -2,13 +2,6 @@
 # Configure the OpenVPN server module.
 #-------------------------------------------------------------------------------
 
-# ------------------------------------------------------------------------------
-# We can get the account ID of the Shared Services account from the
-# default provider's caller identity.
-# ------------------------------------------------------------------------------
-data "aws_caller_identity" "default" {
-}
-
 locals {
   # OpenVPN currently only uses a single public subnet, so grab the
   # CIDR of the one with the smallest third octet.

--- a/organization.tf
+++ b/organization.tf
@@ -1,0 +1,5 @@
+# This resource is used to look up account names corresponding to
+# account IDs and vice versa.
+data "aws_organizations_organization" "cool" {
+  provider = aws.organizationsreadonly
+}

--- a/providers.tf
+++ b/providers.tf
@@ -5,7 +5,7 @@ provider "aws" {
 
 provider "aws" {
   alias   = "public_dns"
-  profile = "cool-olddns-route53fullaccess"
+  profile = "cool-dns-route53resourcechange-cyber.dhs.gov"
   region  = var.aws_region
 }
 

--- a/providers.tf
+++ b/providers.tf
@@ -20,3 +20,9 @@ provider "aws" {
   profile = "cool-images-provisionparameterstorereadroles"
   region  = var.aws_region
 }
+
+provider "aws" {
+  alias   = "organizationsreadonly"
+  profile = "cool-master-organizationsreadonly"
+  region  = var.aws_region
+}

--- a/remote_states.tf
+++ b/remote_states.tf
@@ -33,3 +33,18 @@ data "terraform_remote_state" "freeipa" {
 
   workspace = terraform.workspace
 }
+
+data "terraform_remote_state" "public_dns" {
+  backend = "s3"
+
+  config = {
+    encrypt        = true
+    bucket         = "cisa-cool-terraform-state"
+    dynamodb_table = "terraform-state-lock"
+    profile        = "cool-terraform-backend"
+    region         = "us-east-1"
+    key            = "cool-dns-cyber.dhs.gov.tfstate"
+  }
+
+  workspace = "production"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -70,12 +70,6 @@ variable "provisionopenvpn_policy_name" {
   default     = "ProvisionOpenVPN"
 }
 
-variable "public_zone_name" {
-  type        = string
-  description = "The name of the public Route53 zone where public DNS records should be created (e.g. \"cyber.dhs.gov.\")."
-  default     = "cyber.dhs.gov."
-}
-
 variable "tags" {
   type        = map(string)
   description = "Tags to apply to all AWS resources created."


### PR DESCRIPTION
## 🗣 Description

In this pull request I dynamically determine the correct Images account to use when searching for AMIs.  I also switch to using the new COOL DNS account for public DNS, and I update the code to adapt to changes made in cisagov/openvpn-server-tf-module#19.

## 💭 Motivation and Context

This change is required to deploy a COOL staging environment.

## 🧪 Testing

I used these changes, together with those in cisagov/openvpn-server-tf-module#19, to deploy a COOL staging environment.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
