### PR TITLE
Remove direct ssh access

### DIFF
--- a/.github/lineage.yml
+++ b/.github/lineage.yml
@@ -1,0 +1,6 @@
+---
+version: "1"
+
+lineage:
+  skeleton:
+    remote-url: https://github.com/cisagov/skeleton-generic.git

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ env:
   PIP_CACHE_DIR: ~/.cache/pip
   PRE_COMMIT_CACHE_DIR: ~/.cache/pre-commit
   RUN_TMATE: ${{ secrets.RUN_TMATE }}
-  TF_CACHE_DIR: .terraform
 
 jobs:
   lint:
@@ -61,11 +60,6 @@ jobs:
         with:
           path: ${{ steps.go-cache.outputs.dir }}
           key: "${{ runner.os }}-go"
-      - name: Cache Terraform initialization
-        uses: actions/cache@v1
-        with:
-          path: ${{ env.TF_CACHE_DIR }}
-          key: "${{ runner.os }}-terraform-initialization"
       - name: Install Terraform
         run: |
           mkdir -p ${{ env.CURL_CACHE_DIR }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,7 @@ jobs:
         run: |
           for path in [[ $(find . -type f -iname "*.tf" -exec dirname "{}" \; \
             | sort -u) ]]; do \
+            echo "Initializing '$path'..." \
             terraform init -upgrade=true -input=false -backend=false "$path"; \
             done
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           for path in $(find . -type f -iname "*.tf" -exec dirname "{}" \; \
             | sort -u); do \
-            echo "Initializing '$path'...\n" \
+            echo "Initializing '$path'..."; \
             terraform init -upgrade=true -input=false -backend=false "$path"; \
             done
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,9 +75,9 @@ jobs:
         run: GO111MODULE=on go get github.com/segmentio/terraform-docs
       - name: Find and initialize Terraform directories
         run: |
-          for path in [[ $(find . -type f -iname "*.tf" -exec dirname "{}" \; \
-            | sort -u) ]]; do \
-            echo "Initializing '$path'..." \
+          for path in $(find . -type f -iname "*.tf" -exec dirname "{}" \; \
+            | sort -u); do \
+            echo "Initializing '$path'...\n" \
             terraform init -upgrade=true -input=false -backend=false "$path"; \
             done
       - name: Install dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,6 +89,9 @@ repos:
       # https://github.com/hashicorp/terraform/pull/24896
       # is a proprosed fix to deal with `terraform validate` with proxy
       # providers (among other configurations).
+      # We have decided to disable the terraform_validate hook until the issues
+      # above have been resolved, which we hope will be with the release of
+      # Terraform 0.13.
       # - id: terraform_validate
   - repo: https://github.com/IamTheFij/docker-pre-commit
     rev: v1.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
     hooks:
       - id: shell-lint
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.0a2
+    rev: 3.8.1
     hooks:
       - id: flake8
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,10 +64,10 @@ repos:
     rev: v2.1.1
     hooks:
       - id: seed-isort-config
-  - repo: https://github.com/pre-commit/mirrors-isort
+  - repo: https://github.com/timothycrosley/isort
     # pick the isort version you'd like to use from
     # https://github.com/pre-commit/mirrors-isort/releases
-    rev: v4.3.21
+    rev: 4.3.21
     hooks:
       - id: isort
   - repo: https://github.com/ansible/ansible-lint.git

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,13 +27,13 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.22.0
+    rev: v0.23.0
     hooks:
       - id: markdownlint
         args:
           - --config=.mdl_config.json
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.21.0
+    rev: v1.23.0
     hooks:
       - id: yamllint
   - repo: https://github.com/detailyang/pre-commit-shell
@@ -41,13 +41,13 @@ repos:
     hooks:
       - id: shell-lint
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.8.0a2
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.1.0
+    rev: v2.4.1
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
@@ -61,7 +61,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.1.0
+    rev: v2.1.1
     hooks:
       - id: seed-isort-config
   - repo: https://github.com/pre-commit/mirrors-isort
@@ -71,12 +71,12 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v4.2.0
+    rev: v4.3.0a0
     hooks:
       - id: ansible-lint
       # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
-    rev: v1.29.0
+    rev: v1.30.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -85,7 +85,7 @@ repos:
     hooks:
       - id: docker-compose-check
   - repo: https://github.com/prettier/prettier
-    rev: 2.0.4
+    rev: 2.0.5
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,7 +77,19 @@ repos:
     rev: v1.30.0
     hooks:
       - id: terraform_fmt
-      - id: terraform_validate
+      # There are ongoing issues with how this command works. This issue
+      # documents the core issue:
+      # https://github.com/hashicorp/terraform/issues/21408
+      # We have seen issues primarily with proxy providers and Terraform code
+      # that uses remote state. The PR
+      # https://github.com/hashicorp/terraform/pull/24887
+      # has been approved and is part of the 0.13 release to resolve the issue
+      # with remote states.
+      # The PR
+      # https://github.com/hashicorp/terraform/pull/24896
+      # is a proprosed fix to deal with `terraform validate` with proxy
+      # providers (among other configurations).
+      # - id: terraform_validate
   - repo: https://github.com/IamTheFij/docker-pre-commit
     rev: v1.0.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,8 +65,6 @@ repos:
     hooks:
       - id: seed-isort-config
   - repo: https://github.com/timothycrosley/isort
-    # pick the isort version you'd like to use from
-    # https://github.com/pre-commit/mirrors-isort/releases
     rev: 4.3.21
     hooks:
       - id: isort

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ has been applied
 | provisionopenvpn_policy_description | The description to associate with the IAM policy that allows provisioning of OpenVPN in the Shared Services account. | `string` | `Allows provisioning of OpenVPN in the Shared Services account.` | no |
 | provisionopenvpn_policy_name | The name to assign the IAM policy that allows provisioning of OpenVPN in the Shared Services account. | `string` | `ProvisionOpenVPN` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
-| trusted_cidr_blocks_ssh | A list of the CIDR blocks that are allowed to access the ssh port on the VPN servers (e.g. ["10.10.0.0/16", "10.11.0.0/16"]). | `list(string)` | `[]` | no |
 | trusted_cidr_blocks_vpn | A list of the CIDR blocks that are allowed to access the VPN port on the VPN servers (e.g. ["10.10.0.0/16", "10.11.0.0/16"]). | `list(string)` | `[]` | no |
 
 ## Outputs ##

--- a/openvpn.tf
+++ b/openvpn.tf
@@ -78,7 +78,6 @@ module "openvpn" {
   ]
   subnet_id               = data.terraform_remote_state.networking.outputs.public_subnets[local.openvpn_subnet_cidr].id
   tags                    = merge(var.tags, map("Name", "OpenVPN"))
-  trusted_cidr_blocks_ssh = var.trusted_cidr_blocks_ssh
   trusted_cidr_blocks_vpn = var.trusted_cidr_blocks_vpn
   vpn_group               = "vpnusers"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -82,12 +82,6 @@ variable "tags" {
   default     = {}
 }
 
-variable "trusted_cidr_blocks_ssh" {
-  type        = list(string)
-  description = "A list of the CIDR blocks that are allowed to access the ssh port on the VPN servers (e.g. [\"10.10.0.0/16\", \"10.11.0.0/16\"])."
-  default     = []
-}
-
 variable "trusted_cidr_blocks_vpn" {
   type        = list(string)
   description = "A list of the CIDR blocks that are allowed to access the VPN port on the VPN servers (e.g. [\"10.10.0.0/16\", \"10.11.0.0/16\"])."


### PR DESCRIPTION
## 🗣 Description

This pull request removes direct ssh access for the VPN server.

## 💭 Motivation and Context

Now that we can access the instance via SSM Session Manager there is no need to leave port 22 open.  Security++!

## 🧪 Testing

I have deployed these changes to our staging environment and verified that they perform as expected.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
