### PR TITLE
Remove FreeIPA admin PW and add FreeIPA domain

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # these owners will be requested for review when someone
 # opens a pull request.
-*       @dav3r @felddy @hillaryj @jsf9k @mcdonnnj @cisagov/team-ois
+* @dav3r @felddy @jsf9k

--- a/openvpn.tf
+++ b/openvpn.tf
@@ -63,7 +63,7 @@ module "openvpn" {
   client_dns_server        = var.client_dns_server
   client_motd_url          = var.client_motd_url
   client_network           = var.client_network
-  freeipa_admin_pw         = var.freeipa_admin_pw
+  freeipa_domain           = var.cool_domain
   freeipa_realm            = upper(var.cool_domain)
   hostname                 = "vpn.${var.cool_domain}"
   private_networks         = var.private_networks

--- a/variables.tf
+++ b/variables.tf
@@ -18,11 +18,6 @@ variable "client_network" {
   description = "A string containing the network and netmask to assign client addresses. The server will take the first address. (e.g. \"10.240.0.0 255.255.255.0\")."
 }
 
-variable "freeipa_admin_pw" {
-  type        = string
-  description = "The password for the Kerberos admin role."
-}
-
 # ------------------------------------------------------------------------------
 # Optional parameters
 #


### PR DESCRIPTION
## 🗣 Description

This pull request removes the FreeIPA admin password from and adds the FreeIPA domain to the [cisagov/openvpn-server-tf-module](https://github.com/cisagov/openvpn-server-tf-module) configuration.

## 💭 Motivation and Context

These changes are necessary to agree with cisagov/openvpn-server-tf-module#31.

## 🧪 Testing

I successfully deployed a new OpenVPN server to our staging environment with these changes.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
