### PR TITLE
Add the VENOM security group to the OpenVPN instance

### DIFF
--- a/openvpn.tf
+++ b/openvpn.tf
@@ -47,7 +47,8 @@ module "openvpn" {
   private_zone_id          = data.terraform_remote_state.networking.outputs.private_zone.id
   public_zone_id           = data.terraform_remote_state.public_dns.outputs.cyber_dhs_gov_zone.id
   security_groups = [
-    data.terraform_remote_state.freeipa.outputs.client_security_group.id
+    data.terraform_remote_state.freeipa.outputs.client_security_group.id,
+    data.terraform_remote_state.venom.outputs.venom_security_group.id,
   ]
   ssm_read_role_accounts_allowed = [
     data.aws_caller_identity.sharedservices.account_id

--- a/remote_states.tf
+++ b/remote_states.tf
@@ -108,3 +108,18 @@ data "terraform_remote_state" "sharedservices" {
 
   workspace = terraform.workspace
 }
+
+data "terraform_remote_state" "venom" {
+  backend = "s3"
+
+  config = {
+    encrypt        = true
+    bucket         = "cisa-cool-terraform-state"
+    dynamodb_table = "terraform-state-lock"
+    profile        = "cool-terraform-backend"
+    region         = "us-east-1"
+    key            = "cool-sharedservices-venom/terraform.tfstate"
+  }
+
+  workspace = terraform.workspace
+}


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds the VENOM security group to the OpenVPN instance.

## 💭 Motivation and context ##

This change will allow the VENOM agents running on the OpenVPN instances to communicate with resources in the VENOM environment.  This is required for integration with the VENOM environment.

## 🧪 Testing ##

All `pre-commit` hooks pass.  These changes have already been applied to the COOL staging environment.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
