### PR TITLE
Correctly reference CDM security group

### DIFF
--- a/openvpn.tf
+++ b/openvpn.tf
@@ -48,7 +48,7 @@ module "openvpn" {
   public_zone_id           = data.terraform_remote_state.public_dns.outputs.cyber_dhs_gov_zone.id
   security_groups = [
     data.terraform_remote_state.freeipa.outputs.client_security_group.id,
-    data.terraform_remote_state.venom.outputs.venom_security_group.id,
+    data.terraform_remote_state.cdm.outputs.cdm_security_group.id,
   ]
   ssm_read_role_accounts_allowed = [
     data.aws_caller_identity.sharedservices.account_id

--- a/remote_states.tf
+++ b/remote_states.tf
@@ -109,7 +109,7 @@ data "terraform_remote_state" "sharedservices" {
   workspace = terraform.workspace
 }
 
-data "terraform_remote_state" "venom" {
+data "terraform_remote_state" "cdm" {
   backend = "s3"
 
   config = {
@@ -118,7 +118,7 @@ data "terraform_remote_state" "venom" {
     dynamodb_table = "terraform-state-lock"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
-    key            = "cool-sharedservices-venom/terraform.tfstate"
+    key            = "cool-sharedservices-cdm/terraform.tfstate"
   }
 
   workspace = terraform.workspace


### PR DESCRIPTION
## 🗣 Description ##

This pull request adjusts the Terraform code to correctly reference the CDM security group.

## 💭 Motivation and context ##

The remote state containing the CDM security group, and the Terraform resource name corresponding to it, have both changes names; therefore the references to them must also be updated.

## 🧪 Testing ##

I successfully applied these changes to our COOL staging environment.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
