### PR TITLE
Give VPN users access to services running in assessment environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ has been applied.
 
 | Name | Description |
 |------|-------------|
+| assessment\_environment\_services\_access\_security\_group | The security group allowing VPN users access to services running in the assessment environments. |
 | instance\_id | The ID corresponding to the OpenVPN server EC2 instance. |
 | security\_group\_id | The ID corresponding to the OpenVPN server security group. |
 

--- a/egress_to_assessment_env_services_sg.tf
+++ b/egress_to_assessment_env_services_sg.tf
@@ -4,7 +4,7 @@ resource "aws_security_group" "assessment_environment_services_access" {
   description = "Security group allowing access to assessment environment services."
 }
 
-# Access to assessment environment services (e.g., guacamole,
+# Access to assessment environment services (e.g., Guacamole,
 # Mattermost, etc.)
 resource "aws_security_group_rule" "egress_to_assessment_env_services" {
   for_each = local.assessment_env_service_ports

--- a/egress_to_assessment_env_services_sg.tf
+++ b/egress_to_assessment_env_services_sg.tf
@@ -1,0 +1,18 @@
+# Security group for assessment environment access
+resource "aws_security_group" "assessment_environment_services_access" {
+  vpc_id      = data.terraform_remote_state.networking.outputs.vpc.id
+  description = "Security group allowing access to assessment environment services"
+}
+
+# Access to assessment environment services (e.g., guacamole,
+# Mattermost, etc.)
+resource "aws_security_group_rule" "egress_to_assessment_env_services" {
+  for_each = local.assessment_env_service_ports
+
+  security_group_id = aws_security_group.assessment_environment_services_access.id
+  type              = "egress"
+  protocol          = each.value["protocol"]
+  cidr_blocks       = [data.terraform_remote_state.networking.outputs.cool_cidr_block]
+  from_port         = each.value["port"]
+  to_port           = each.value["port"]
+}

--- a/egress_to_assessment_env_services_sg.tf
+++ b/egress_to_assessment_env_services_sg.tf
@@ -1,7 +1,7 @@
 # Security group for assessment environment access
 resource "aws_security_group" "assessment_environment_services_access" {
   vpc_id      = data.terraform_remote_state.networking.outputs.vpc.id
-  description = "Security group allowing access to assessment environment services"
+  description = "Security group allowing access to assessment environment services."
 }
 
 # Access to assessment environment services (e.g., guacamole,

--- a/locals.tf
+++ b/locals.tf
@@ -39,7 +39,7 @@ locals {
 
   # Ports to be accessed in assessment environments (e.g. for
   # Guacamole, Mattermost, etc.)
-  assessment_env_ports = {
+  assessment_env_service_ports = {
     http = {
       port     = 80
       protocol = "tcp"

--- a/locals.tf
+++ b/locals.tf
@@ -53,7 +53,7 @@ locals {
       protocol = "udp"
     },
     mm_unknown1 = {
-      port     = 5379
+      port     = 5349
       protocol = "tcp"
     },
     mm_web = {

--- a/locals.tf
+++ b/locals.tf
@@ -36,4 +36,33 @@ locals {
     for cidr in data.terraform_remote_state.networking.outputs.vpc_endpoint_s3.cidr_blocks :
     format("%s %s", split("/", cidr)[0], cidrnetmask(cidr))
   ]
+
+  # Ports to be accessed in assessment environments (e.g. for
+  # Guacamole, Mattermost, etc.)
+  assessment_env_ports = {
+    http = {
+      port     = 80
+      protocol = "tcp"
+    },
+    https = {
+      port     = 443
+      protocol = "tcp"
+    },
+    mm_unknown0 = {
+      port     = 3478
+      protocol = "udp"
+    },
+    mm_unknown1 = {
+      port     = 5379
+      protocol = "tcp"
+    },
+    mm_web = {
+      port     = 8065
+      protocol = "tcp"
+    },
+    mm_unknown2 = {
+      port     = 10000
+      protocol = "udp"
+    },
+  }
 }

--- a/openvpn.tf
+++ b/openvpn.tf
@@ -52,6 +52,7 @@ module "openvpn" {
   security_groups = [
     data.terraform_remote_state.freeipa.outputs.client_security_group.id,
     data.terraform_remote_state.cdm.outputs.cdm_security_group.id,
+    aws_security_group.assessment_environment_services_access.id,
   ]
   ssm_read_role_accounts_allowed = [
     data.aws_caller_identity.sharedservices.account_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
+output "assessment_environment_services_access_security_group" {
+  value       = aws_security_group.assessment_environment_services_access
+  description = "The security group allowing VPN users access to services running in the assessment environments."
+}
+
 output "instance_id" {
   value       = module.openvpn.id
   description = "The ID corresponding to the OpenVPN server EC2 instance."


### PR DESCRIPTION
## 🗣 Description ##

This pull request gives VPN users access to services running in assessment environments.

## 💭 Motivation and context ##

Previously the list of such services included only our remote desktop gateway solution, which only needed a standard web port that was already allowed out, but now the list has grown to include some services that use other ports.

## 🧪 Testing ##

All `pre-commit` hooks pass.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
