### PR TITLE
Add standard CloudWatch instance alarms for the OpenVPN instance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # These owners will be the default owners for everything in the
 # repo. Unless a later match takes precedence, these owners will be
 # requested for review when someone opens a pull request.
-* @dav3r @felddy @jsf9k
+* @dav3r @felddy @jsf9k @mcdonnnj
 
 # These folks own any files in the .github directory at the root of
 # the repository and any of its subdirectories.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ has been applied.
 
 | Name | Source | Version |
 |------|--------|---------|
-| cw\_alarms\_openvpn | github.com/cisagov/instance-cw-alarms-tf-module | first-commits |
+| cw\_alarms\_openvpn | github.com/cisagov/instance-cw-alarms-tf-module | n/a |
 | openvpn | github.com/cisagov/openvpn-server-tf-module | n/a |
 
 ## Resources ##

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ has been applied.
 
 | Name | Source | Version |
 |------|--------|---------|
+| cw\_alarms\_openvpn | github.com/cisagov/instance-cw-alarms-tf-module | first-commits |
 | openvpn | github.com/cisagov/openvpn-server-tf-module | n/a |
 
 ## Resources ##

--- a/openvpn.tf
+++ b/openvpn.tf
@@ -67,7 +67,7 @@ module "cw_alarms_openvpn" {
   providers = {
     aws = aws.provision_sharedservices
   }
-  source = "github.com/cisagov/instance-cw-alarms-tf-module?ref=first-commits"
+  source = "github.com/cisagov/instance-cw-alarms-tf-module"
 
   alarm_actions = [data.terraform_remote_state.sharedservices.outputs.cw_alarm_sns_topic.arn]
   instance_ids = [

--- a/openvpn.tf
+++ b/openvpn.tf
@@ -61,3 +61,18 @@ module "openvpn" {
   trusted_cidr_blocks_vpn = var.trusted_cidr_blocks_vpn
   vpn_group               = "vpnusers"
 }
+
+# CloudWatch alarms for the OpenVPN instance
+module "cw_alarms_openvpn" {
+  providers = {
+    aws = aws.provision_sharedservices
+  }
+  source = "github.com/cisagov/instance-cw-alarms-tf-module?ref=first-commits"
+
+  alarm_actions = [data.terraform_remote_state.sharedservices.outputs.cw_alarm_sns_topic.arn]
+  instance_ids = [
+    module.openvpn.id,
+  ]
+  insufficient_data_actions = [data.terraform_remote_state.sharedservices.outputs.cw_alarm_sns_topic.arn]
+  ok_actions                = [data.terraform_remote_state.sharedservices.outputs.cw_alarm_sns_topic.arn]
+}


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a set of standard CloudWatch instance alarms for the OpenVPN instance.

## 💭 Motivation and context ##

These alarms will notify us via email if any of the following should occur:
- Either of an instance's status checks (instance or system) fail
- Any IMDSv1 requests succeed
- CPU, memory, or disk utilization is high
- Any packets are queued and/or dropped because the a networking limitation was exceeded for the instance

## 🧪 Testing ##

All automated testing passes.  This code is also already applied to the Shared Services account in our COOL staging environment.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Revert dependencies to default branches.