### PR TITLE
Use a security group for S3 VPC endpoint access

### DIFF
--- a/openvpn.tf
+++ b/openvpn.tf
@@ -50,10 +50,10 @@ module "openvpn" {
   private_zone_id          = data.terraform_remote_state.networking.outputs.private_zone.id
   public_zone_id           = data.terraform_remote_state.public_dns.outputs.cyber_dhs_gov_zone.id
   security_groups = [
-    data.terraform_remote_state.networking.outputs.s3_endpoint_client_security_group.id,
-    data.terraform_remote_state.freeipa.outputs.client_security_group.id,
-    data.terraform_remote_state.cdm.outputs.cdm_security_group.id,
     aws_security_group.assessment_environment_services_access.id,
+    data.terraform_remote_state.cdm.outputs.cdm_security_group.id,
+    data.terraform_remote_state.freeipa.outputs.client_security_group.id,
+    data.terraform_remote_state.networking.outputs.s3_endpoint_client_security_group.id,
   ]
   ssm_read_role_accounts_allowed = [
     data.aws_caller_identity.sharedservices.account_id

--- a/openvpn.tf
+++ b/openvpn.tf
@@ -50,6 +50,7 @@ module "openvpn" {
   private_zone_id          = data.terraform_remote_state.networking.outputs.private_zone.id
   public_zone_id           = data.terraform_remote_state.public_dns.outputs.cyber_dhs_gov_zone.id
   security_groups = [
+    data.terraform_remote_state.networking.outputs.s3_endpoint_client_security_group.id,
     data.terraform_remote_state.freeipa.outputs.client_security_group.id,
     data.terraform_remote_state.cdm.outputs.cdm_security_group.id,
     aws_security_group.assessment_environment_services_access.id,


### PR DESCRIPTION
## 🗣 Description ##

This pull request uses the security group created in cisagov/cool-sharedservices-networking#70 to allow the OpenVPN instance to access the S3 VPC endpoint.

See also:
- cisagov/cool-sharedservices-networking#70

## 💭 Motivation and context ##

Using an SG in this way matches the paradigm used in [cisagov/cool-assessment-terraform](https://github.com/cisagov/cool-assessment-terraform), where individual SGs are used for each "facet" of an EC2 instance's network access.

## 🧪 Testing ##

I applied these changes as well as those from cisagov/cool-sharedservices-networking#70 to our COOL staging environment and verified that they function as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.