### PR TITLE
Add some security groups to the OpenVPN instance

### DIFF
--- a/openvpn.tf
+++ b/openvpn.tf
@@ -53,7 +53,11 @@ module "openvpn" {
     aws_security_group.assessment_environment_services_access.id,
     data.terraform_remote_state.cdm.outputs.cdm_security_group.id,
     data.terraform_remote_state.freeipa.outputs.client_security_group.id,
+    data.terraform_remote_state.networking.outputs.cloudwatch_agent_endpoint_client_security_group.id,
     data.terraform_remote_state.networking.outputs.s3_endpoint_client_security_group.id,
+    data.terraform_remote_state.networking.outputs.ssm_agent_endpoint_client_security_group.id,
+    data.terraform_remote_state.networking.outputs.ssm_endpoint_client_security_group.id,
+    data.terraform_remote_state.networking.outputs.sts_endpoint_client_security_group.id,
   ]
   ssm_read_role_accounts_allowed = [
     data.aws_caller_identity.sharedservices.account_id


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds some security groups to the OpenVPN instance.

## 💭 Motivation and context ##

The OpenVPN instance requires these security groups to communicate with the VPC endpoints created in cisagov/cool-sharedservices-networking#71.

## 🧪 Testing ##

All automated tests pass.  I also applied these changes to our COOL staging environment and verified that they function as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.