### PR TITLE
Allow additional ports for AO VPN endpoints

### DIFF
--- a/egress_to_assessment_env_services_sg.tf
+++ b/egress_to_assessment_env_services_sg.tf
@@ -6,8 +6,8 @@ resource "aws_security_group" "assessment_environment_services_access" {
   description = "Security group allowing access to assessment environment services."
 }
 
-# Access to assessment environment services (e.g., Guacamole,
-# Mattermost, etc.)
+# Access to assessment environment services (e.g. for Advanced Ops VPN
+# endpoints, Guacamole, Mattermost, etc.)
 resource "aws_security_group_rule" "egress_to_assessment_env_services" {
   provider = aws.provision_sharedservices
   for_each = local.assessment_env_service_ports
@@ -16,6 +16,6 @@ resource "aws_security_group_rule" "egress_to_assessment_env_services" {
   type              = "egress"
   protocol          = each.value["protocol"]
   cidr_blocks       = [data.terraform_remote_state.networking.outputs.cool_cidr_block]
-  from_port         = each.value["port"]
-  to_port           = each.value["port"]
+  from_port         = each.value["from_port"]
+  to_port           = each.value["to_port"]
 }

--- a/locals.tf
+++ b/locals.tf
@@ -38,31 +38,42 @@ locals {
   ]
 
   # Ports to be accessed in assessment environments (e.g. for
-  # Guacamole, Mattermost, etc.)
+  # Advanced Ops VPN endpoints, Guacamole, Mattermost, etc.)
   assessment_env_service_ports = {
+    ao_vpn_endpoints = {
+      from_port = 51820
+      protocol  = "udp"
+      to_port   = 51835
+    },
     http = {
-      port     = 80
-      protocol = "tcp"
+      from_port = 80
+      protocol  = "tcp"
+      to_port   = 80
     },
     https = {
-      port     = 443
-      protocol = "tcp"
+      from_port = 443
+      protocol  = "tcp"
+      to_port   = 443
     },
     mm_unknown0 = {
-      port     = 3478
-      protocol = "udp"
+      from_port = 3478
+      protocol  = "udp"
+      to_port   = 3478
     },
     mm_unknown1 = {
-      port     = 5349
-      protocol = "tcp"
+      from_port = 5349
+      protocol  = "tcp"
+      to_port   = 5349
     },
     mm_web = {
-      port     = 8065
-      protocol = "tcp"
+      from_port = 8065
+      protocol  = "tcp"
+      to_port   = 8065
     },
     mm_unknown2 = {
-      port     = 10000
-      protocol = "udp"
+      from_port = 10000
+      protocol  = "udp"
+      to_port   = 10000
     },
   }
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR opens some additional UDP ports in the "OpenVPN" security group.  Since a port range was required here, I also modified the code to support ranges similar to how we do this elsewhere. 

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

These additional ports will be used to communicate with various VPN endpoints created and used by the Advanced Operations team in their assessments.

This PR is related to these others:
* https://github.com/cisagov/cool-assessment-terraform/pull/205
* https://github.com/cisagov/cool-assessment-terraform/pull/206

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I verified that these changes could be successfully applied in the Staging environment.

These networking changes were tested by @quietpirate in Staging, who verified that he was able to successfully communicate with an instance in an assessment environment via the newly-opened ports.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Apply these changes to Production.
