### PR TITLE
Bump up OpenVPN instance size to a t3.medium

### DIFF
--- a/openvpn.tf
+++ b/openvpn.tf
@@ -30,8 +30,8 @@ module "openvpn" {
   }
 
   ami_owner_account_id = local.images_account_id
-  # aws_instance_type       = "t3.small"
-  cert_bucket_name = var.cert_bucket_name
+  aws_instance_type    = "t3.medium"
+  cert_bucket_name     = var.cert_bucket_name
   cert_read_role_accounts_allowed = [
     data.aws_caller_identity.sharedservices.account_id
   ]


### PR DESCRIPTION
## 🗣 Description ##

This pull request bumps up the OpenVPN instance size from a `t3.small` to a `t3.medium`.

## 💭 Motivation and context ##

In debugging an issue I saw that the `clamscan` process takes up over a gig of RAM when it is running.  Bumping up to a `t3.medium` gives the instance 4GB RAM vs 2GB, so this should put us ahead of any memory contention issues.

## 🧪 Testing ##

- All automated tests pass.
- I applied these changes to our staging COOL environment and verified that they resulted in a functioning instance of the expected type.  As a bonus, this change is nondestructive and hence can be applied to a live instance without any interruption in service.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.