### PR TITLE
Increase size of OpenVPN instance's root disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ has been applied.
 | provisionaccount\_role\_name | The name of the IAM role that allows sufficient permissions to provision all AWS resources in the Shared Services account. | `string` | `"ProvisionAccount"` | no |
 | provisionopenvpn\_policy\_description | The description to associate with the IAM policy that allows provisioning of OpenVPN in the Shared Services account. | `string` | `"Allows provisioning of OpenVPN in the Shared Services account."` | no |
 | provisionopenvpn\_policy\_name | The name to assign the IAM policy that allows provisioning of OpenVPN in the Shared Services account. | `string` | `"ProvisionOpenVPN"` | no |
+| root\_disk\_size | The size of the OpenVPN instance's root disk in GiB. | `number` | `8` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
 | trusted\_cidr\_blocks\_vpn | A list of the CIDR blocks that are allowed to access the VPN port on the VPN servers (e.g. ["10.10.0.0/16", "10.11.0.0/16"]). | `list(string)` | `[]` | no |
 

--- a/openvpn.tf
+++ b/openvpn.tf
@@ -20,7 +20,7 @@ locals {
 }
 
 module "openvpn" {
-  source = "github.com/cisagov/openvpn-server-tf-module?ref=improvement%2Fadd-input-var-for-disk-size"
+  source = "github.com/cisagov/openvpn-server-tf-module"
 
   providers = {
     aws                = aws.provision_sharedservices

--- a/openvpn.tf
+++ b/openvpn.tf
@@ -20,7 +20,7 @@ locals {
 }
 
 module "openvpn" {
-  source = "github.com/cisagov/openvpn-server-tf-module"
+  source = "github.com/cisagov/openvpn-server-tf-module?ref=improvement%2Fadd-input-var-for-disk-size"
 
   providers = {
     aws                = aws.provision_sharedservices

--- a/openvpn.tf
+++ b/openvpn.tf
@@ -51,6 +51,7 @@ module "openvpn" {
   private_reverse_zone_id                   = data.terraform_remote_state.networking.outputs.public_subnet_private_reverse_zones[local.openvpn_subnet_cidr].id
   private_zone_id                           = data.terraform_remote_state.networking.outputs.private_zone.id
   public_zone_id                            = data.terraform_remote_state.public_dns.outputs.cyber_dhs_gov_zone.id
+  root_disk_size                            = var.root_disk_size
   security_groups = [
     aws_security_group.assessment_environment_services_access.id,
     data.terraform_remote_state.cdm.outputs.cdm_security_group.id,

--- a/variables.tf
+++ b/variables.tf
@@ -101,6 +101,12 @@ variable "provisionopenvpn_policy_name" {
   default     = "ProvisionOpenVPN"
 }
 
+variable "root_disk_size" {
+  type        = number
+  description = "The size of the OpenVPN instance's root disk in GiB."
+  default     = 8
+}
+
 variable "tags" {
   type        = map(string)
   description = "Tags to apply to all AWS resources created."


### PR DESCRIPTION
## 🗣 Description ##

This pull request leverages cisagov/openvpn-server-tf-module#99 to increase the size of the OpenVPN instance's root disk.

## 💭 Motivation and context ##

Resolves cisagov/openvpn-server-tf-module#98.  We need to set the size to a larger value than the size of the AMI since the CDM tools can eventually consume a lot of disk space.

## 🧪 Testing ##

All automated tests pass.  I also deployed these changes to staging and verified that they functioned as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Revert dependencies to default branches.