### PR TITLE
Change OpenVPN instance type from `t3.medium` to `c5n.large`

### DIFF
--- a/openvpn.tf
+++ b/openvpn.tf
@@ -30,7 +30,7 @@ module "openvpn" {
   }
 
   ami_owner_account_id = local.images_account_id
-  aws_instance_type    = "t3.medium"
+  aws_instance_type    = "c5n.large"
   cert_bucket_name     = var.cert_bucket_name
   cert_read_role_accounts_allowed = [
     data.aws_caller_identity.sharedservices.account_id


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR modifies the OpenVPN EC2 instance type from `t3.medium` to `c5n.large`.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This is being done in order to take advantage of the improved network bandwidth of "up to 25 Gbps" with `c5n.large` vs. "up to 5 Gbps" with `t3.medium`, as well as the higher baseline bandwidth of the `c5n.large` instance type (3 Gbps vs. 256 Mbps with the `t3.medium`).

For more info, see https://github.com/cisagov/cool-system-internal/issues/142.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

This change was manually applied in Staging and Production, so this PR is being created retroactively.

Several bandwidth tests were conducted in both Staging and Production, all of which point to improved throughput after the change in this PR (if you have access, see https://github.com/cisagov/cool-system-internal/issues/142 for details).

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
