### PR TITLE
Use a Graviton instance for the VPN server

### DIFF
--- a/openvpn.tf
+++ b/openvpn.tf
@@ -20,7 +20,7 @@ locals {
 }
 
 module "openvpn" {
-  source = "github.com/cisagov/openvpn-server-tf-module?ref=improvement%2Fuse-arm64-ami"
+  source = "github.com/cisagov/openvpn-server-tf-module"
 
   providers = {
     aws                = aws.provision_sharedservices

--- a/openvpn.tf
+++ b/openvpn.tf
@@ -20,7 +20,7 @@ locals {
 }
 
 module "openvpn" {
-  source = "github.com/cisagov/openvpn-server-tf-module"
+  source = "github.com/cisagov/openvpn-server-tf-module?ref=improvement%2Fuse-arm64-ami"
 
   providers = {
     aws                = aws.provision_sharedservices
@@ -30,7 +30,7 @@ module "openvpn" {
   }
 
   ami_owner_account_id = local.images_account_id
-  aws_instance_type    = "c5n.large"
+  aws_instance_type    = "c6gn.large"
   cert_bucket_name     = var.cert_bucket_name
   cert_read_role_accounts_allowed = [
     data.aws_caller_identity.sharedservices.account_id


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Terraform code to use a Graviton instance type for the OpenVPN server that is comparable to the x86_64 instance type that was being used before.

See also:
- cisagov/openvpn-packer#113
- cisagov/openvpn-server-tf-module#101

## 💭 Motivation and context ##

Graviton instances are more efficient and cheaper, which is better for our pocketbook and the environment.

## 🧪 Testing ##

All automated tests pass. I also deployed a Graviton OpenVPN instance to our staging COOL environment with these changes and verified that it functions as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Revert to using the default branch of [cisagov/openvpn-server-tf-module](https://github.com/cisagov/openvpn-server-tf-module) once cisagov/openvpn-server-tf-module#101 has been merged.